### PR TITLE
gsip: two ReadAt correctness fixes

### DIFF
--- a/gsip/gsip.go
+++ b/gsip/gsip.go
@@ -141,8 +141,12 @@ func (r *Reader) acquireReader(off int64) (*gzip.Reader, error) {
 		return nil, fmt.Errorf("could not find any checkpoints or readers for offset %d", off)
 	}
 
-	// TODO: Do we need to bound the size?
-	sr := io.NewSectionReader(r.ra, highest.In, r.size)
+	// SectionReader's third arg is length, not absolute end. Passing
+	// r.size let downstream reads ask the underlying ReaderAt for bytes
+	// in [highest.In, highest.In + r.size) — i.e. up to r.size past the
+	// blob's end when highest.In > 0. Real Range-capable transports
+	// reject those requests with 416.
+	sr := io.NewSectionReader(r.ra, highest.In, r.size-highest.In)
 
 	zr, err := gzip.Continue(sr, 0, highest, nil)
 	if err != nil {

--- a/gsip/gsip.go
+++ b/gsip/gsip.go
@@ -177,7 +177,14 @@ func (r *Reader) ReadAt(p []byte, off int64) (int, error) {
 
 	n, err := io.ReadFull(zr, p)
 	if err != nil {
-		return 0, fmt.Errorf("ReadFull at %d: %w", off, err)
+		// io.ReaderAt contract: a short read at end-of-stream must return
+		// the partial bytes plus io.EOF, not (0, io.ErrUnexpectedEOF). The
+		// latter loses data and breaks callers that wrap the Reader in
+		// io.SectionReader / bufio.Reader (e.g. tarfs.Index).
+		if err == io.ErrUnexpectedEOF || err == io.EOF {
+			return n, io.EOF
+		}
+		return n, fmt.Errorf("ReadFull at %d: %w", off, err)
 	}
 
 	return n, nil

--- a/gsip/gsip_test.go
+++ b/gsip/gsip_test.go
@@ -3,6 +3,7 @@ package gsip
 import (
 	"bytes"
 	"compress/gzip"
+	"fmt"
 	"io"
 	"math/rand/v2"
 	"os"
@@ -86,5 +87,77 @@ func TestReadAtShortReadAtEOF(t *testing.T) {
 	}
 	if string(p[:n]) != want {
 		t.Errorf("got %q, want %q", p[:n], want)
+	}
+}
+
+// strictReaderAt is an io.ReaderAt that errors loudly if asked to read
+// past the size of its underlying buffer. Real-world Range-capable
+// transports (e.g. registry blob endpoints) return 416 in that case.
+type strictReaderAt struct {
+	data []byte
+	t    *testing.T
+}
+
+func (s *strictReaderAt) ReadAt(p []byte, off int64) (int, error) {
+	if off < 0 || off+int64(len(p)) > int64(len(s.data)) {
+		err := fmt.Errorf("ReadAt past end of stream: off=%d len=%d size=%d", off, len(p), len(s.data))
+		s.t.Error(err)
+		return 0, err
+	}
+	return copy(p, s.data[off:off+int64(len(p))]), nil
+}
+
+// TestAcquireReaderRespectsBlobBounds asserts that ReadAt via the
+// checkpoint path (acquireReader's "no exact-match reader, find highest
+// checkpoint <= off" branch) doesn't ask the underlying reader for bytes
+// past the blob's end. The internal SectionReader's third arg is a
+// length, not an absolute end — passing total size as the length lets
+// downstream reads spill past the blob.
+func TestAcquireReaderRespectsBlobBounds(t *testing.T) {
+	// Enough plaintext to ensure multiple flate-block checkpoints.
+	plaintext := bytes.Repeat([]byte("Lorem ipsum dolor sit amet, consectetur adipiscing elit. "), 50000)
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	if _, err := gw.Write(plaintext); err != nil {
+		t.Fatal(err)
+	}
+	if err := gw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	sra := &strictReaderAt{data: buf.Bytes(), t: t}
+	r, err := NewReader(sra, int64(buf.Len()))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Sequentially drain the stream so the frontier reader emits all
+	// flate-block checkpoints.
+	chunk := make([]byte, 1<<16)
+	for off := int64(0); off < int64(len(plaintext)); {
+		n, err := r.ReadAt(chunk, off)
+		if err != nil && err != io.EOF {
+			t.Fatalf("sequential drain at %d: %v", off, err)
+		}
+		off += int64(n)
+		if n == 0 {
+			break
+		}
+	}
+
+	// Now ReadAt at an offset the frontier reader has already passed.
+	// acquireReader must take the checkpoint path and must not request
+	// bytes past the blob's end.
+	target := make([]byte, 64)
+	targetOff := int64(len(plaintext) - 200)
+	n, err := r.ReadAt(target, targetOff)
+	if err != nil && err != io.EOF {
+		t.Fatalf("checkpoint ReadAt: %v", err)
+	}
+	if n != len(target) {
+		t.Errorf("n = %d, want %d", n, len(target))
+	}
+	if !bytes.Equal(target[:n], plaintext[targetOff:targetOff+int64(n)]) {
+		t.Errorf("content mismatch at offset %d", targetOff)
 	}
 }

--- a/gsip/gsip_test.go
+++ b/gsip/gsip_test.go
@@ -1,6 +1,9 @@
 package gsip
 
 import (
+	"bytes"
+	"compress/gzip"
+	"io"
 	"math/rand/v2"
 	"os"
 	"testing"
@@ -48,5 +51,40 @@ func TestGsip(t *testing.T) {
 		if n != zn {
 			t.Fatalf("ReadAt(%d, %d): %d != %d", start, len(b), n, zn)
 		}
+	}
+}
+
+// TestReadAtShortReadAtEOF asserts that a ReadAt whose buffer extends past
+// the end of the decompressed stream returns the partial bytes plus
+// io.EOF, not (0, io.ErrUnexpectedEOF). This honors the io.ReaderAt
+// contract; without it, downstream wrappers (io.SectionReader, bufio
+// inside tar.Reader, etc.) silently lose the tail of the stream.
+func TestReadAtShortReadAtEOF(t *testing.T) {
+	const want = "hello, world"
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	if _, err := gw.Write([]byte(want)); err != nil {
+		t.Fatal(err)
+	}
+	if err := gw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Ask for more decompressed bytes than exist.
+	p := make([]byte, 1024)
+	n, err := r.ReadAt(p, 0)
+	if n != len(want) {
+		t.Errorf("n = %d, want %d", n, len(want))
+	}
+	if err != io.EOF {
+		t.Errorf("err = %v, want io.EOF", err)
+	}
+	if string(p[:n]) != want {
+		t.Errorf("got %q, want %q", p[:n], want)
 	}
 }


### PR DESCRIPTION
## Summary

Two independent bug fixes in `gsip.Reader.ReadAt` surfaced while building a FUSE driver that uses `gsip` + `tarfs` + `ranger` to browse OCI image content via HTTP Range requests.

### 1. `ReadAt` should return `(n, io.EOF)` on short read at end of stream

The `io.ReaderAt` contract requires that a short read at end-of-stream return the partial bytes plus `io.EOF`, not `(0, io.ErrUnexpectedEOF)`. Today `ReadAt` maps every `io.ReadFull` error — including the `ErrUnexpectedEOF` that signals a partial-but-valid tail read — to `(0, fmt.Errorf(...))`. That loses data and breaks downstream wrappers (`io.SectionReader`, `bufio.Reader` inside `tar.Reader`, etc.). In particular `tarfs.Index` reading a `gsip`-backed `SectionReader` through `tar.Reader`'s internal bufio loses the tail of the archive.

### 2. `acquireReader` checkpoint `SectionReader` is unbounded past blob end

`acquireReader`'s checkpoint path calls `io.NewSectionReader(r.ra, highest.In, r.size)`. The third arg is the section's length, not its absolute end; passing `r.size` makes the section's limit `highest.In + r.size`, i.e. up to `r.size` past the blob's end whenever `highest.In > 0`.

Forgiving `io.ReaderAt`s silently return short reads at EOF, so the bug stays invisible. Strict ones — including HTTP Range-capable transports against real registries that return 416 for ranges past blob size — fail.

Each fix has a regression test:
- `TestReadAtShortReadAtEOF` — gzips a small string, asks for more decompressed bytes than exist, expects `(11, io.EOF)`.
- `TestAcquireReaderRespectsBlobBounds` — gzips ~3MB of plaintext, drains it sequentially to populate checkpoints, then `ReadAt`s near the end (forcing the checkpoint path) through a strict `io.ReaderAt` that t.Errors if asked to read past the blob's declared size.

Both are isolated to `gsip/gsip.go` (~10 lines of behavior change combined). Happy to split into two PRs if you'd prefer atomic merges.

Context: these fixes are vendored in [imjasonh/ocifuse](https://github.com/imjasonh/ocifuse) (`third_party/targz/`) and exercised by mounting real OCI images from Docker Hub end-to-end.

## Test plan

- [x] `go test ./gsip/...` passes locally
- [x] both new tests fail without the corresponding fix (verified by applying tests first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)