### PR TITLE
Add `Prune` to trim checkpoint history windows

### DIFF
--- a/gsip/gsip.go
+++ b/gsip/gsip.go
@@ -90,6 +90,36 @@ func NewReader(ra io.ReaderAt, size int64) (*Reader, error) {
 	return r, nil
 }
 
+// newReaderWithSpan is like [NewReader] but lets callers control the minimum
+// number of decompressed bytes between checkpoints.  Used in tests to force
+// multiple checkpoints over small inputs without reading megabytes of data.
+func newReaderWithSpan(ra io.ReaderAt, size, span int64) (*Reader, error) {
+	updates := make(chan *flate.Checkpoint, 10)
+	sr := io.NewSectionReader(ra, 0, size)
+	br := bufio.NewReaderSize(sr, 1<<20)
+	zr, err := gzip.NewReaderWithSpans(br, span, updates)
+	if err != nil {
+		return nil, fmt.Errorf("gzip.NewReaderWithSpans: %w", err)
+	}
+	r := &Reader{
+		ra:          ra,
+		size:        size,
+		updates:     updates,
+		checkpoints: []*flate.Checkpoint{},
+		readers:     map[*gzip.Reader]bool{zr: true},
+	}
+	r.goroutineDone = make(chan struct{})
+	go func() {
+		defer close(r.goroutineDone)
+		for checkpoint := range updates {
+			r.mu.Lock()
+			r.checkpoints = append(r.checkpoints, checkpoint)
+			r.mu.Unlock()
+		}
+	}()
+	return r, nil
+}
+
 func (r *Reader) acquireReader(off int64) (*gzip.Reader, error) {
 	r.mu.Lock()
 
@@ -210,6 +240,73 @@ func (r *Reader) Wait() {
 	}
 	r.closeOnce.Do(func() { close(r.updates) })
 	<-r.goroutineDone
+}
+
+// linearTail extracts the minimum ring-buffer bytes needed to resume
+// decompression from cp: all pending bytes [RdPos, WrPos) that will be
+// served before new decompression, plus maxDist lookback bytes immediately
+// before RdPos for satisfying back-references.  Returns a flat chronological
+// slice starting at (RdPos − lookback) in ring order.
+// Returns nil when nothing needs storing (pending == 0 and maxDist == 0).
+func linearTail(cp *flate.Checkpoint, maxDist int) []byte {
+	hist := cp.History()
+	wrPos := cp.WrPos
+	rdPos := cp.RdPos
+	pending := wrPos - rdPos
+
+	// available lookback before rdPos (served history in the ring)
+	avail := rdPos
+	if cp.Full {
+		// full ring: served history = total ring − pending bytes
+		avail = len(hist) - pending
+	}
+	lookback := maxDist
+	if lookback > avail {
+		lookback = avail
+	}
+
+	total := lookback + pending
+	if total == 0 {
+		return nil
+	}
+
+	tail := make([]byte, total)
+	start := (rdPos - lookback + len(hist)) % len(hist)
+	if start < wrPos {
+		copy(tail, hist[start:wrPos])
+	} else {
+		// tail spans the ring wrap: [start, len(hist)) then [0, wrPos)
+		first := copy(tail, hist[start:])
+		copy(tail[first:], hist[:wrPos])
+	}
+	return tail
+}
+
+// Prune trims each checkpoint's stored history window to the minimum bytes
+// needed to resume decompression: pending ring bytes (served before any new
+// decompression) plus the MaxDist lookback for back-references.  Call after
+// [Reader.Wait] and before [Reader.Encode].
+//
+// Prune is a no-op on readers created by [Decode] and on checkpoints where
+// no savings are possible (or that have already been pruned).
+func (r *Reader) Prune() {
+	if r.goroutineDone == nil {
+		return // Decode path: MaxDist was never computed during a scan.
+	}
+	r.mu.Lock()
+	checkpoints := make([]*flate.Checkpoint, len(r.checkpoints))
+	copy(checkpoints, r.checkpoints)
+	r.mu.Unlock()
+
+	for _, cp := range checkpoints {
+		if cp.IsEmpty() || len(cp.History()) != 1<<15 {
+			continue // empty sentinel or already pruned
+		}
+		tail := linearTail(cp, cp.MaxDist)
+		if tail != nil && len(tail) < len(cp.History()) {
+			cp.SetHistory(tail)
+		}
+	}
 }
 
 type reader struct {

--- a/gsip/internal/flate/inflate.go
+++ b/gsip/internal/flate/inflate.go
@@ -386,6 +386,9 @@ type Decompressor struct {
 	span    int64
 	last    int64
 	updates chan<- *Checkpoint
+
+	segmentMaxDist    int         // max back-ref distance since the last checkpoint
+	pendingCheckpoint *Checkpoint // last emitted checkpoint, awaiting MaxDist finalization
 }
 
 func (f *Decompressor) nextBlock() {
@@ -688,6 +691,9 @@ readLiteral:
 		}
 
 		f.copyLen, f.copyDist = length, dist
+		if dist > f.segmentMaxDist {
+			f.segmentMaxDist = dist
+		}
 		goto copyHistory
 	}
 
@@ -778,6 +784,12 @@ func (f *Decompressor) finishBlock() {
 		f.err = io.EOF
 	}
 	if f.updates != nil && (woffset-f.last > f.span) {
+		if f.pendingCheckpoint != nil {
+			f.pendingCheckpoint.MaxDist = f.segmentMaxDist
+			f.pendingCheckpoint = nil
+		}
+		f.segmentMaxDist = 0 // always reset; tracks distances since the new checkpoint
+
 		checkpoint := &Checkpoint{
 			Hist:  make([]byte, len(f.dict.hist)),
 			In:    f.roffset,
@@ -792,6 +804,14 @@ func (f *Decompressor) finishBlock() {
 
 		f.updates <- checkpoint
 		f.last = checkpoint.Out
+
+		if !f.final {
+			f.pendingCheckpoint = checkpoint
+		}
+	} else if f.final && f.pendingCheckpoint != nil {
+		// EOF without a new checkpoint: finalize the last segment.
+		f.pendingCheckpoint.MaxDist = f.segmentMaxDist
+		f.pendingCheckpoint = nil
 	}
 	f.step = (*Decompressor).nextBlock
 }
@@ -981,6 +1001,11 @@ type Checkpoint struct {
 
 	// Optional gzip header.
 	GzipHeader *Header `json:"header,omitempty"`
+
+	// MaxDist is the maximum back-reference distance seen in the deflate
+	// segment that follows this checkpoint. Set during the initial scan;
+	// used by Prune to trim Hist. Not serialized.
+	MaxDist int `json:"-"`
 }
 
 func (c *Checkpoint) History() []byte {
@@ -1031,7 +1056,28 @@ func Continue(r io.Reader, from *Checkpoint, span int64, updates chan<- *Checkpo
 
 	f.dict = dictDecoder{}
 	f.dict.hist = make([]byte, maxMatchOffset)
-	copy(f.dict.hist, from.Hist)
+	if len(from.Hist) == maxMatchOffset {
+		copy(f.dict.hist, from.Hist)
+	} else {
+		// linear tail format: Hist holds a chronological slice of the ring
+		// from (RdPos − lookback) to WrPos, where lookback = len(Hist) −
+		// pending and pending = WrPos − RdPos.  Place the slice back at
+		// the same ring positions so pending bytes and back-references both
+		// resolve correctly.
+		tail := from.Hist
+		if L := len(tail); L > 0 {
+			pending := from.WrPos - from.RdPos
+			lookback := L - pending
+			start := (from.RdPos - lookback + maxMatchOffset) % maxMatchOffset
+			if start < from.WrPos {
+				copy(f.dict.hist[start:from.WrPos], tail)
+			} else {
+				n := maxMatchOffset - start
+				copy(f.dict.hist[start:], tail[:n])
+				copy(f.dict.hist[:from.WrPos], tail[n:])
+			}
+		}
+	}
 	f.dict.wrPos = from.WrPos
 	f.dict.rdPos = from.RdPos
 	f.dict.full = from.Full

--- a/gsip/prune_test.go
+++ b/gsip/prune_test.go
@@ -1,0 +1,163 @@
+package gsip
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"testing"
+)
+
+// gzipData compresses data with the stdlib gzip writer.
+func gzipData(t *testing.T, data []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	if _, err := gw.Write(data); err != nil {
+		t.Fatal(err)
+	}
+	if err := gw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+// drainReader sequentially reads all plaintext bytes through r (building the
+// checkpoint index as a side-effect) and then calls Wait.
+func drainReader(t *testing.T, r *Reader, size int64) {
+	t.Helper()
+	chunk := make([]byte, 1<<14)
+	for off := int64(0); off < size; {
+		n, err := r.ReadAt(chunk, off)
+		off += int64(n)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("drainReader at %d: %v", off, err)
+		}
+	}
+	r.Wait()
+}
+
+// checkReadAt verifies that r.ReadAt returns the expected bytes at several
+// representative offsets across the plaintext.
+func checkReadAt(t *testing.T, r *Reader, plaintext []byte) {
+	t.Helper()
+	size := int64(len(plaintext))
+	for _, off := range []int64{0, size / 4, size / 2, size - 64} {
+		if off < 0 {
+			off = 0
+		}
+		p := make([]byte, 64)
+		n, err := r.ReadAt(p, off)
+		if err != nil && err != io.EOF {
+			t.Fatalf("ReadAt(%d): %v", off, err)
+		}
+		if !bytes.Equal(p[:n], plaintext[off:off+int64(n)]) {
+			t.Errorf("ReadAt(%d): content mismatch", off)
+		}
+	}
+}
+
+// TestPruneReducesHist verifies that:
+//   - Before Prune, every non-empty checkpoint stores the full 32 KiB window.
+//   - After Prune, non-empty checkpoints have a shorter window (proving that
+//     pending + lookback bytes were computed and applied).
+//   - ReadAt remains correct after pruning (exercising the linear-tail restore
+//     path in Continue).
+//
+// The 12-byte repeating pattern keeps all back-reference distances at ≤ 12.
+// The compressed blob is ~518 bytes → 1 deflate block → 1 non-empty checkpoint
+// (fired when the span is exceeded).  Prune trims that checkpoint's Hist from
+// 32 KiB to (pending + lookback) bytes, well under the original 32 KiB.
+func TestPruneReducesHist(t *testing.T) {
+	plaintext := bytes.Repeat([]byte("hello world "), 20000) // ~240 KiB
+	compressed := gzipData(t, plaintext)
+
+	// span=64 KiB causes a checkpoint to fire at the deflate block boundary.
+	r, err := newReaderWithSpan(bytes.NewReader(compressed), int64(len(compressed)), 1<<16)
+	if err != nil {
+		t.Fatal(err)
+	}
+	drainReader(t, r, int64(len(plaintext)))
+
+	nonEmpty := 0
+	for _, cp := range r.checkpoints {
+		if cp.IsEmpty() {
+			continue
+		}
+		nonEmpty++
+		if got := len(cp.History()); got != 1<<15 {
+			t.Errorf("before Prune: checkpoint Hist len = %d, want 32768", got)
+		}
+	}
+	if nonEmpty < 1 {
+		t.Fatalf("need at least 1 non-empty checkpoint, got 0")
+	}
+
+	r.Prune()
+
+	anyPruned := false
+	for _, cp := range r.checkpoints {
+		if !cp.IsEmpty() && len(cp.History()) < 1<<15 {
+			anyPruned = true
+			break
+		}
+	}
+	if !anyPruned {
+		t.Error("Prune did not reduce any checkpoint's Hist")
+	}
+
+	checkReadAt(t, r, plaintext)
+}
+
+// TestPruneEncodeDecodeRoundtrip verifies that Prune + Encode + Decode
+// preserves ReadAt correctness through the full serialization cycle.
+// This exercises the linear-tail restore path in Continue on a decoded index.
+func TestPruneEncodeDecodeRoundtrip(t *testing.T) {
+	plaintext := bytes.Repeat([]byte("hello world "), 20000)
+	compressed := gzipData(t, plaintext)
+
+	r, err := newReaderWithSpan(bytes.NewReader(compressed), int64(len(compressed)), 1<<16)
+	if err != nil {
+		t.Fatal(err)
+	}
+	drainReader(t, r, int64(len(plaintext)))
+	r.Prune()
+
+	var idx bytes.Buffer
+	if err := r.Encode(&idx); err != nil {
+		t.Fatal(err)
+	}
+
+	r2, err := Decode(bytes.NewReader(compressed), int64(len(compressed)), &idx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	checkReadAt(t, r2, plaintext)
+}
+
+// TestPruneNoopOnDecode verifies that calling Prune on a Decode-path reader
+// is safe (the goroutineDone guard fires) and does not corrupt ReadAt results.
+func TestPruneNoopOnDecode(t *testing.T) {
+	plaintext := bytes.Repeat([]byte("hello world "), 20000)
+	compressed := gzipData(t, plaintext)
+
+	r, err := newReaderWithSpan(bytes.NewReader(compressed), int64(len(compressed)), 1<<16)
+	if err != nil {
+		t.Fatal(err)
+	}
+	drainReader(t, r, int64(len(plaintext)))
+
+	var idx bytes.Buffer
+	if err := r.Encode(&idx); err != nil {
+		t.Fatal(err)
+	}
+
+	r2, err := Decode(bytes.NewReader(compressed), int64(len(compressed)), &idx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r2.Prune() // must be a no-op, not a panic or corruption
+	checkReadAt(t, r2, plaintext)
+}


### PR DESCRIPTION
`(*Reader).Prune` reduces the in-memory footprint of the checkpoint index by trimming each checkpoint's `Hist` from the full 32 KiB ring to the minimum bytes needed to resume decompression: the pending bytes still in the ring at checkpoint time plus the maximum back-reference distance seen in the deflate segment that follows.

To know that maximum distance, the decompressor now tracks `segmentMaxDist` and a `pendingCheckpoint` pointer.  When a new checkpoint fires, the previous checkpoint's `MaxDist` is finalized; at EOF the last open segment is closed out.  `MaxDist` is not serialized (`json:"-"`) -- it is a scan-time quantity, so `Prune` is a no-op on `Decode`-path readers (guarded by the `goroutineDone == nil` check).

`Continue` is updated to reconstruct the full ring from the compact linear-tail format: given the chronological slice and the original `RdPos`/`WrPos`, it places bytes back at the correct ring positions so pending bytes and back-references both resolve correctly.

Assisted-By: "claude my eyes right out"